### PR TITLE
feat: Restructured fields and logics in "+ New Event" pop-up with updated colour categories

### DIFF
--- a/app/static/css/timetable.css
+++ b/app/static/css/timetable.css
@@ -86,6 +86,12 @@
     background: var(--blue);
 }
 
+/* Time input — pointer cursor on clock icon only + dark mode tint */
+input[type="time"].tp-input::-webkit-calendar-picker-indicator { cursor: pointer; }
+html.dark input[type="time"].tp-input::-webkit-calendar-picker-indicator {
+    filter: invert(1) opacity(0.5);
+}
+
 /* Popup animation */
 @keyframes popIn {
     from { opacity: 0; transform: scale(0.94) translateY(8px); }

--- a/app/static/js/timetable.js
+++ b/app/static/js/timetable.js
@@ -140,6 +140,20 @@ if (document.getElementById('addEventBtn')) {
     document.getElementById('addEventBtn').addEventListener('click', () => {
         popupOverlay.style.display    = 'flex';
         popupOverlay.style.background = 'var(--overlay-bg)';
+
+        // Default day: mini cal selection if it falls in current week, else today
+        const weekStart = getWeekStart();
+        const target    = (typeof calSelected !== 'undefined' && calSelected)
+                            ? new Date(calSelected)
+                            : new Date();
+        target.setHours(0, 0, 0, 0);
+        let defaultDay = 0;
+        for (let i = 0; i < 7; i++) {
+            const d = new Date(weekStart); d.setDate(d.getDate() + i);
+            if (sameDay(d, target)) { defaultDay = i; break; }
+        }
+        document.getElementById('evDay').value = defaultDay;
+
         document.getElementById('evTitle').focus();
     });
 }

--- a/app/static/js/timetable.js
+++ b/app/static/js/timetable.js
@@ -13,6 +13,15 @@ _timeBody.style.setProperty('--num-hours', NUM_HOURS);
 const DAY_NAMES = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
 let weekOffset  = 0;
 
+const CATEGORY_COLORS = {
+    'Personal': '#d6bf6c',
+    'Studies':  '#5e99f0',
+    'Work':     '#f68383',
+    'Social':   '#a729d0',
+    'Health':   '#f2a061',
+    'Finance':  '#5bbb81',
+};
+
 let events = [];
 
 // Helpers 
@@ -95,10 +104,11 @@ function buildColumns() {
             const top    = fracToY(timeToFrac(ev.start));
             const height = fracToY(timeToFrac(ev.end)) - top;
             const el     = document.createElement('div');
-            el.className    = `cal-event ${ev.color}`;
-            el.style.top    = `${top}px`;
-            el.style.height = `${Math.max(height - 4, 20)}px`;
-            el.innerHTML    = `<div class="ev-title">${ev.title}</div><div class="ev-time">${formatTime(ev.start)} – ${formatTime(ev.end)}</div>`;
+            el.className             = 'cal-event';
+            el.style.top             = `${top}px`;
+            el.style.height          = `${Math.max(height - 4, 20)}px`;
+            el.style.backgroundColor = CATEGORY_COLORS[ev.category] || CATEGORY_COLORS['Personal'];
+            el.innerHTML             = `<div class="ev-title">${ev.title}</div><div class="ev-time">${formatTime(ev.start)} – ${formatTime(ev.end)}</div>`;
             col.appendChild(el);
         });
 
@@ -162,22 +172,24 @@ if (document.getElementById('btn-popup-close')) document.getElementById('btn-pop
 
 if (document.getElementById('saveBtn')) {
     document.getElementById('saveBtn').addEventListener('click', () => {
-        const title = document.getElementById('evTitle').value.trim();
-        const day   = parseInt(document.getElementById('evDay').value);
-        const start = document.getElementById('evStart').value;
-        const end   = document.getElementById('evEnd').value;
-        const color = document.getElementById('evColor').value;
+        const title    = document.getElementById('evTitle').value.trim();
+        const day      = parseInt(document.getElementById('evDay').value);
+        const start    = document.getElementById('evStart').value;
+        const end      = document.getElementById('evEnd').value;
+        const category = document.getElementById('evCategory').value;
+        const note     = document.getElementById('evNote').value.trim();
 
         if (!title || !start || !end || start >= end) {
             alert('Please fill in all fields and ensure start time is before end time.');
             return;
         }
 
-        events.push({ title, day, start, end, color });
-        if (typeof window.onEventSave === 'function') window.onEventSave({ title, day, start, end, color });
+        events.push({ title, day, start, end, category, note });
+        if (typeof window.onEventSave === 'function') window.onEventSave({ title, day, start, end, category, note });
         closepopup();
         buildColumns();
         document.getElementById('evTitle').value = '';
+        document.getElementById('evNote').value  = '';
     });
 }
 

--- a/app/templates/personal.html
+++ b/app/templates/personal.html
@@ -247,15 +247,21 @@
                 </div>
             </div>
 
-            <div class="mb-5">
-                <label class="block text-xs tracking-widest mb-1" style="color: var(--text-label);">Colour</label>
-                <select id="evColor" class="tp-input">
-                    <option value="bg-blue-500">Blue</option>
-                    <option value="bg-emerald-500">Green</option>
-                    <option value="bg-orange-500">Orange</option>
-                    <option value="bg-rose-500">Red</option>
-                    <option value="bg-purple-500">Purple</option>
+            <div class="mb-3">
+                <label class="block text-xs tracking-widest mb-1" style="color: var(--text-label);">Category</label>
+                <select id="evCategory" class="tp-input">
+                    <option value="Personal">Personal</option>
+                    <option value="Studies">Studies</option>
+                    <option value="Work">Work</option>
+                    <option value="Social">Social</option>
+                    <option value="Health">Health</option>
+                    <option value="Finance">Finance</option>
                 </select>
+            </div>
+
+            <div class="mb-5">
+                <label class="block text-xs tracking-widest mb-1" style="color: var(--text-label);">Note <span style="color: var(--text-fine);">(optional)</span></label>
+                <textarea id="evNote" placeholder="Add a note…" class="tp-input" rows="2" style="resize: none;"></textarea>
             </div>
 
             <div class="flex justify-end gap-2">


### PR DESCRIPTION
Closes #20 
- Default day is now the current day, else it is the selected day on the calendar, making it more intuitive to create events.
- Changed the colour of the clock symbol in dark mode to grey and added pointer cursor on mouse hover.
- Colours follow categories: Studies, Work, Social, Health, Finance, Personal.
- Added additional "Notes" section that will only show up on event pop-up from the timetable.