### PR TITLE
feat: Event details pop-up with delete and edit buttons

### DIFF
--- a/app/static/js/timetable.js
+++ b/app/static/js/timetable.js
@@ -22,7 +22,8 @@ const CATEGORY_COLORS = {
     'Finance':  '#5bbb81',
 };
 
-let events = [];
+let events     = [];
+let editingIdx = null;
 
 // Helpers 
 function getWeekStart() {
@@ -116,7 +117,10 @@ function buildColumns() {
             el.style.top             = `${top}px`;
             el.style.height          = `${Math.max(height - 4, 20)}px`;
             el.style.backgroundColor = CATEGORY_COLORS[ev.category] || CATEGORY_COLORS['Personal'];
-            el.innerHTML             = `<div class="ev-title">${ev.title}</div><div class="ev-time">${formatTime(ev.start)} – ${formatTime(ev.end)}</div>`;
+            el.innerHTML   = `<div class="ev-title">${ev.title}</div><div class="ev-time">${formatTime(ev.start)} – ${formatTime(ev.end)}</div>`;
+            el.style.cursor = 'pointer';
+            const capturedIdx = events.indexOf(ev);
+            el.addEventListener('click', (e) => { e.stopPropagation(); openEventDetail(capturedIdx); });
             col.appendChild(el);
         });
 
@@ -151,7 +155,12 @@ function buildColumns() {
 // New Event Pop-up (only on personal page)
 const popupOverlay = document.getElementById('popupOverlay');
 
-function closepopup() { if (popupOverlay) popupOverlay.style.display = 'none'; }
+function closepopup() {
+    if (popupOverlay) popupOverlay.style.display = 'none';
+    editingIdx = null;
+    const pt = document.getElementById('popup-title');
+    if (pt) pt.textContent = 'New Event';
+}
 function handleOverlayClick(e) { if (e.target === popupOverlay) closepopup(); }
 
 if (document.getElementById('addEventBtn')) {
@@ -192,8 +201,13 @@ if (document.getElementById('saveBtn')) {
             return;
         }
 
-        events.push({ title, date, start, end, category, note });
-        if (typeof window.onEventSave === 'function') window.onEventSave({ title, date, start, end, category, note });
+        if (editingIdx !== null) {
+            const old = events[editingIdx];
+            events.splice(editingIdx, 1, { title, date, start, end, category, note, dbId: old.dbId });
+        } else {
+            events.push({ title, date, start, end, category, note });
+            if (typeof window.onEventSave === 'function') window.onEventSave({ title, date, start, end, category, note });
+        }
         closepopup();
         buildColumns();
         document.getElementById('evTitle').value = '';
@@ -208,7 +222,42 @@ document.getElementById('todayBtn').addEventListener('click', () => {
     if (typeof jumpToDate === 'function') jumpToDate(new Date());
 });
 
-// Init 
+// Event detail popup
+const evDetailOverlay = document.getElementById('evDetailOverlay');
+
+function closeEventDetail() {
+    if (evDetailOverlay) evDetailOverlay.style.display = 'none';
+}
+
+function handleDetailOverlayClick(e) {
+    if (e.target === evDetailOverlay) closeEventDetail();
+}
+
+function openEventDetail(idx) {
+    const ev = events[idx];
+    if (!ev) return;
+
+    document.getElementById('det-color-bar').style.background = CATEGORY_COLORS[ev.category] || CATEGORY_COLORS['Personal'];
+    document.getElementById('det-title').textContent    = ev.title;
+    document.getElementById('det-category').textContent = ev.category;
+
+    const d = new Date(ev.date + 'T00:00:00');
+    document.getElementById('det-date').textContent = d.toLocaleDateString('en-AU', { weekday: 'long', day: 'numeric', month: 'long', year: 'numeric' });
+    document.getElementById('det-time').textContent = `${formatTime(ev.start)} – ${formatTime(ev.end)}`;
+
+    const noteRow = document.getElementById('det-note-row');
+    document.getElementById('det-note').textContent = ev.note || '';
+    noteRow.style.display = ev.note ? '' : 'none';
+
+    evDetailOverlay.style.display    = 'flex';
+    evDetailOverlay.style.background = 'var(--overlay-bg)';
+}
+
+if (document.getElementById('btn-detail-close')) {
+    document.getElementById('btn-detail-close').addEventListener('click', closeEventDetail);
+}
+
+// Init
 renderWeekHeaders();
 buildColumns();
 document.getElementById('time-body').scrollTop = (7 - START_HOUR) * HOUR_HEIGHT;

--- a/app/static/js/timetable.js
+++ b/app/static/js/timetable.js
@@ -249,8 +249,36 @@ function openEventDetail(idx) {
     document.getElementById('det-note').textContent = ev.note || '';
     noteRow.style.display = ev.note ? '' : 'none';
 
+    document.getElementById('det-edit-btn').onclick   = () => editEvent(idx);
+    document.getElementById('det-delete-btn').onclick = () => deleteEvent(idx);
+
     evDetailOverlay.style.display    = 'flex';
     evDetailOverlay.style.background = 'var(--overlay-bg)';
+}
+
+function editEvent(idx) {
+    const ev = events[idx];
+    if (!ev) return;
+    closeEventDetail();
+    editingIdx = idx;
+
+    document.getElementById('evTitle').value    = ev.title;
+    document.getElementById('evDay').value      = ev.date;
+    document.getElementById('evStart').value    = ev.start;
+    document.getElementById('evEnd').value      = ev.end;
+    document.getElementById('evCategory').value = ev.category;
+    document.getElementById('evNote').value     = ev.note || '';
+
+    const pt = document.getElementById('popup-title');
+    if (pt) pt.textContent = 'Edit Event';
+
+    popupOverlay.style.display    = 'flex';
+    popupOverlay.style.background = 'var(--overlay-bg)';
+}
+
+function deleteEvent(idx) {
+    // Frontend-only placeholder — no action yet
+    closeEventDetail();
 }
 
 if (document.getElementById('btn-detail-close')) {

--- a/app/templates/personal.html
+++ b/app/templates/personal.html
@@ -352,6 +352,12 @@
                 <p id="det-note" class="text-sm" style="color: var(--text-subtitle);"></p>
             </div>
 
+            <!-- Actions -->
+            <div class="flex justify-end gap-2">
+                <button id="det-delete-btn" class="px-4 py-2 text-sm rounded-full border" style="border-color:#fca5a5; color:#ef4444; background:transparent;">Delete</button>
+                <button id="det-edit-btn" class="btn-blue px-4 py-2 text-sm">Edit</button>
+            </div>
+
             <button id="btn-detail-close" class="absolute top-4 right-4 w-7 h-7 rounded-full flex items-center justify-center text-lg leading-none cursor-pointer" style="background: var(--bg-close-btn); color: var(--text-label);">&times;</button>
         </div>
     </div>

--- a/app/templates/personal.html
+++ b/app/templates/personal.html
@@ -268,7 +268,7 @@
     <!-- Add Event Pop-up -->
     <div id="popupOverlay" style="display:none; position:fixed; inset:0; z-index:50; align-items:center; justify-content:center; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px);" onclick="handleOverlayClick(event)">
         <div class="popup-box w-full max-w-sm mx-4 relative border" style="background: var(--bg-surface); border-color: var(--border-glass); box-shadow: 0 30px 80px rgba(0,0,0,0.16); border-radius: 1.5rem; padding: 2.25rem; backdrop-filter: blur(28px) saturate(1.8); -webkit-backdrop-filter: blur(28px) saturate(1.8);">
-            <h2 class="text-lg font-semibold mb-4" style="color: var(--dark);">New Event</h2>
+            <h2 id="popup-title" class="text-lg font-semibold mb-4" style="color: var(--dark);">New Event</h2>
 
             <div class="mb-3">
                 <label class="block text-xs tracking-widest mb-1" style="color: var(--text-label);">Title</label>
@@ -314,6 +314,45 @@
             </div>
 
             <button id="btn-popup-close" class="absolute top-4 right-4 w-7 h-7 rounded-full flex items-center justify-center text-lg leading-none cursor-pointer" style="background: var(--bg-close-btn); color: var(--text-label);">&times;</button>
+        </div>
+    </div>
+
+    <!-- Event Detail Pop-up -->
+    <div id="evDetailOverlay" style="display:none; position:fixed; inset:0; z-index:50; align-items:center; justify-content:center; backdrop-filter:blur(6px); -webkit-backdrop-filter:blur(6px);" onclick="handleDetailOverlayClick(event)">
+        <div class="w-full max-w-sm mx-4 relative border" style="background: var(--bg-surface); border-color: var(--border-glass); box-shadow: 0 30px 80px rgba(0,0,0,0.16); border-radius: 1.5rem; padding: 2.25rem; backdrop-filter: blur(28px) saturate(1.8); -webkit-backdrop-filter: blur(28px) saturate(1.8);">
+
+            <!-- Title + category colour -->
+            <div class="flex items-start gap-3 mb-4">
+                <span id="det-color-bar" class="mt-1.5 w-3 h-3 rounded-full shrink-0"></span>
+                <div class="flex-1 min-w-0">
+                    <h2 id="det-title" class="text-lg font-semibold break-words" style="color: var(--dark);"></h2>
+                    <p id="det-category" class="text-xs mt-0.5" style="color: var(--text-subtitle);"></p>
+                </div>
+            </div>
+
+            <!-- Date & time -->
+            <div class="flex flex-col gap-2 mb-4">
+                <div class="flex items-center gap-2">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="shrink-0" style="color:var(--text-ui);">
+                        <rect x="3" y="4" width="18" height="18" rx="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/>
+                    </svg>
+                    <span id="det-date" class="text-sm" style="color: var(--dark);"></span>
+                </div>
+                <div class="flex items-center gap-2">
+                    <svg width="13" height="13" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" class="shrink-0" style="color:var(--text-ui);">
+                        <circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/>
+                    </svg>
+                    <span id="det-time" class="text-sm" style="color: var(--dark);"></span>
+                </div>
+            </div>
+
+            <!-- Notes (hidden when empty) -->
+            <div id="det-note-row" class="mb-5">
+                <p class="text-xs tracking-widest mb-1" style="color: var(--text-label);">Note:</p>
+                <p id="det-note" class="text-sm" style="color: var(--text-subtitle);"></p>
+            </div>
+
+            <button id="btn-detail-close" class="absolute top-4 right-4 w-7 h-7 rounded-full flex items-center justify-center text-lg leading-none cursor-pointer" style="background: var(--bg-close-btn); color: var(--text-label);">&times;</button>
         </div>
     </div>
 


### PR DESCRIPTION
Closes #29 

Edit button redirects the user to a similar pop-up from "+ New event". However, the feature and functionality here is currently local and will reset on page refresh
- Needs backend PUT route logic to map changes to the database, creating a new event while removing the old one

Delete button currently has no actual functionality
- Needs backend DELETE route logic